### PR TITLE
Handle encoding consistently across pythons

### DIFF
--- a/src/preview.py
+++ b/src/preview.py
@@ -1,19 +1,45 @@
+from __future__ import print_function
+import codecs
+import os.path
 import sys
+
 from docutils import core
-filepath = sys.argv[1]
 
-page_string = open(filepath, 'r').read()
+# If Python 3, get a binary STDOUT
+if sys.version_info >= (3,):
+    sys.stdout = sys.stdout.detach()
 
-# page_string = page_string.encode('utf-8', errors="ignore")
+# Make STDOUT utf-8
+sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 
-overrides = {'initial_header_level': 1,
-             'halt_level': 5}
+def main(argv=None):
+    # Some sanity checks on if the path exists.
+    filepath = argv[1] if argv is not None else sys.argv[1]
+    filepath = os.path.abspath(filepath)
+    if not os.path.exists(filepath):
+        return 'File Not Found'
 
-parts = core.publish_parts(
-    source=page_string, source_path=filepath, writer_name='html', settings_overrides=overrides)
+    # open in binary, decode utf-8, and live in unicode
+    with codecs.open(filepath, 'r', 'utf8') as f:
+        page_string = f.read()
 
-html_document = parts['html_body']
-#remove bom
-html_document = html_document.replace('\ufeff', '')
+    overrides = {
+        'initial_header_level': 1,
+        'halt_level': 5,
+    }
 
-print(html_document)
+    parts = core.publish_parts(
+        source=page_string,
+        source_path=filepath,
+        writer_name='html',
+        settings_overrides=overrides,
+    )
+
+    html_document = parts['html_body']
+    html_document = html_document.replace('\ufeff', '')
+
+    # the REAL print function in python 2, now... see top of file
+    print(html_document)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
* Broke the code into a function in case someone wants to import this for some reason
* Python3: made stdout binary
* Use the codecs module to handle encoding of output
* Use the codecs module to open and decode the input file
* Made sure the input file actually exists
* Python2: imported the actual print function